### PR TITLE
Added unit test project.

### DIFF
--- a/ModTek.sln
+++ b/ModTek.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.27428.2043
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModTek", "ModTek\ModTek.csproj", "{8D955C2C-D75B-453C-99D1-B337BBF82CCA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModTekUnitTests", "ModTekUnitTests\ModTekUnitTests.csproj", "{C5DA6F8F-FACF-4CB2-93BD-602D9A084D9B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{8D955C2C-D75B-453C-99D1-B337BBF82CCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D955C2C-D75B-453C-99D1-B337BBF82CCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8D955C2C-D75B-453C-99D1-B337BBF82CCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5DA6F8F-FACF-4CB2-93BD-602D9A084D9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5DA6F8F-FACF-4CB2-93BD-602D9A084D9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5DA6F8F-FACF-4CB2-93BD-602D9A084D9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5DA6F8F-FACF-4CB2-93BD-602D9A084D9B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ModTek/Properties/AssemblyInfo.cs
+++ b/ModTek/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+
+[assembly: InternalsVisibleTo("ModTekUnitTests")]
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information

--- a/ModTekUnitTests/LoadOrderTests.cs
+++ b/ModTekUnitTests/LoadOrderTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ModTek;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ModTekUnitTests
+{
+    [TestClass]
+    public class LoadOrderTests
+    {
+        List<ModDef> mods;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            mods = new List<ModDef>();
+        }
+
+        private void TestLoadOrder(List<ModDef> mods, string[] expectedLoadOrder, string[] expectedSkippedMods)
+        {
+            var skippedMods = new List<string>();
+            var dict = new Dictionary<string, ModDef>();
+            mods.ForEach(m => dict.Add(m.Name, m));
+            var loadOrder = ModTek.ModTek.GetLoadOrder(dict, out skippedMods);
+            
+            Assert.AreEqual(0, skippedMods.Intersect(expectedLoadOrder).Count());
+            Assert.AreEqual(expectedSkippedMods.Length, skippedMods.Union(expectedSkippedMods).Count());
+
+            foreach (var expectedModName in expectedLoadOrder)
+            {
+                Assert.AreEqual(expectedModName, loadOrder.Dequeue().Name);
+            }
+        }
+
+        [TestMethod]
+        public void SimpleMods()
+        {
+            {
+                var modDef = new ModDef();
+                modDef.Name = "modA";
+                mods.Add(modDef);
+            }
+            {
+                var modDef = new ModDef();
+                modDef.Name = "modB";
+                mods.Add(modDef);
+            }
+
+            TestLoadOrder(mods, new[] { "modA", "modB" }, new string[]{});
+        }
+
+        [TestMethod]
+        public void SimpleDependency()
+        {
+            { // simple mod
+                var modDef = new ModDef();
+                modDef.Name = "modA";
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn
+                var modDef = new ModDef();
+                modDef.Name = "modB";
+                modDef.DependsOn.Add("modA");
+                mods.Add(modDef);
+            }
+            
+            TestLoadOrder(mods, new[] { "modA", "modB" }, new string[] { });
+        }
+
+        [TestMethod]
+        public void SimpleDependencyReverseOrder()
+        {
+            { // simple mod
+                var modDef = new ModDef();
+                modDef.Name = "modA";
+                modDef.DependsOn.Add("modB");
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn
+                var modDef = new ModDef();
+                modDef.Name = "modB";
+                mods.Add(modDef);
+            }
+
+            TestLoadOrder(mods, new[] { "modB", "modA" }, new string[] { });
+        }
+
+
+        [TestMethod]
+        public void SimpleTransitiveDependency()
+        {
+            { // simple mod
+                var modDef = new ModDef();
+                modDef.Name = "modA";
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn
+                var modDef = new ModDef();
+                modDef.Name = "modB";
+                modDef.DependsOn.Add("modA");
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn
+                var modDef = new ModDef();
+                modDef.Name = "modC";
+                modDef.DependsOn.Add("modB");
+                mods.Add(modDef);
+            }
+
+            TestLoadOrder(mods, new[] { "modA", "modB", "modC" }, new string[] { });
+        }
+
+        [TestMethod]
+        public void ConflictsAreRemoved()
+        {
+            { // simple mod
+                var modDef = new ModDef();
+                modDef.Name = "modA";
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn
+                var modDef = new ModDef();
+                modDef.Name = "modB";
+                modDef.DependsOn.Add("modA");
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn and ConflictsWith
+                var modDef = new ModDef();
+                modDef.Name = "modC";
+                modDef.DependsOn.Add("modA");
+                modDef.ConflictsWith.Add("modB");
+                mods.Add(modDef);
+            }
+
+            TestLoadOrder(mods, new[] { "modA", "modB" }, new [] { "modC" });
+        }
+        
+        [TestMethod]
+        public void AllConflictsAreRemovedEvenIfEarlier()
+        {
+            { // simple mod
+                var modDef = new ModDef();
+                modDef.Name = "modA";
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn and ConflictsWith
+                var modDef = new ModDef();
+                modDef.Name = "modB";
+                modDef.DependsOn.Add("modA");
+                modDef.ConflictsWith.Add("modC");
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn and ConflictsWith
+                var modDef = new ModDef();
+                modDef.Name = "modC";
+                modDef.DependsOn.Add("modA");
+                modDef.ConflictsWith.Add("modB");
+                mods.Add(modDef);
+            }
+
+            TestLoadOrder(mods, new[] { "modA" }, new[] { "modB", "modC" });
+        }
+
+        [TestMethod]
+        public void AllConflictsAreRemovedEvenWithMissingDependencies()
+        {
+            { // simple mod
+                var modDef = new ModDef();
+                modDef.Name = "modA";
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn and ConflictsWith
+                var modDef = new ModDef();
+                modDef.Name = "modB";
+                modDef.DependsOn.Add("modA");
+                modDef.ConflictsWith.Add("modC");
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn and ConflictsWith
+                var modDef = new ModDef();
+                modDef.Name = "modC";
+                modDef.DependsOn.Add("modX");
+                modDef.ConflictsWith.Add("modB");
+                mods.Add(modDef);
+            }
+
+            TestLoadOrder(mods, new[] { "modA" }, new[] { "modB", "modC" });
+        }
+
+        [TestMethod]
+        public void MissingDependencies()
+        {
+            { // simple mod
+                var modDef = new ModDef();
+                modDef.Name = "modA";
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn
+                var modDef = new ModDef();
+                modDef.Name = "modB";
+                modDef.DependsOn.Add("modX");
+                mods.Add(modDef);
+            }
+
+            TestLoadOrder(mods, new[] { "modA" }, new[] { "modB" });
+        }
+        
+        [TestMethod]
+        public void CyclicDependencies()
+        {
+            { // simple mod
+                var modDef = new ModDef();
+                modDef.Name = "modA";
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn
+                var modDef = new ModDef();
+                modDef.Name = "modB";
+                modDef.DependsOn.Add("modC");
+                mods.Add(modDef);
+            }
+            { // mod with DependsOn
+                var modDef = new ModDef();
+                modDef.Name = "modC";
+                modDef.DependsOn.Add("modB");
+                mods.Add(modDef);
+            }
+
+            TestLoadOrder(mods, new[] { "modA" }, new[] { "modB", "modC" });
+        }
+    }
+}

--- a/ModTekUnitTests/ModTekUnitTests.csproj
+++ b/ModTekUnitTests/ModTekUnitTests.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C5DA6F8F-FACF-4CB2-93BD-602D9A084D9B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ModTekUnitTests</RootNamespace>
+    <AssemblyName>ModTekUnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="LoadOrderTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ModTek\ModTek.csproj">
+      <Project>{8d955c2c-d75b-453c-99d1-b337bbf82cca}</Project>
+      <Name>ModTek</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.1\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/ModTekUnitTests/Properties/AssemblyInfo.cs
+++ b/ModTekUnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ModTekUnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ModTekUnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("c5da6f8f-facf-4cb2-93bd-602d9a084d9b")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ModTekUnitTests/packages.config
+++ b/ModTekUnitTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.2.1" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="1.2.1" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
Included:
* Added unit test project.
The unit tests should be a nice addition.
* Add load order unit tests.
Will help if someone refactores the load order algorithm in the future.
* Refactored load order code.
Might not be your preference, but I find it a bit easier to read.
* Changed conflict behavior, subject to change.

The last point is maybe something to think about, right now you try to maximize the amount of mods to load, but shouldn't a conflict signify that there is an issue with the load order the user has to address?
So don't even try loading a mod that has a conflict, even if the offender can't load due to missing dependencies.
I would even go further and make sure all mods that are denoted to being in conflict to not load at all, even if they have nothing specified as ConflictWith, just soley them being specified as being in conflict by another mod.

What do you think?